### PR TITLE
Correct jni exception: do not use global variables for hProxy instance.

### DIFF
--- a/HicnForwarderAndroid/app/src/main/java/com/cisco/hicn/forwarder/forwarder/ForwarderFragment.java
+++ b/HicnForwarderAndroid/app/src/main/java/com/cisco/hicn/forwarder/forwarder/ForwarderFragment.java
@@ -135,11 +135,7 @@ public class ForwarderFragment extends Fragment {
         Intent intent = new Intent(getActivity(), BackendAndroidService.class);
         getActivity().startService(intent);
 
-
-        HProxy hproxy = HProxy.getInstance();
-
-
-        if (hproxy.isHProxyEnabled()) {
+        if (HProxy.isHProxyEnabled()) {
             Intent intentProxy = null;
 
             intentProxy = BackendProxyService.prepare(getActivity());
@@ -155,8 +151,7 @@ public class ForwarderFragment extends Fragment {
     private void stopBackend() {
         Intent intent = new Intent(getActivity(), BackendAndroidService.class);
         getActivity().stopService(intent);
-        HProxy hproxy = HProxy.getInstance();
-        if (hproxy.isHProxyEnabled()) {
+        if (HProxy.isHProxyEnabled()) {
             this.getActivity().startService(getServiceIntent().setAction(BackendProxyService.ACTION_DISCONNECT));
         }
     }

--- a/HicnForwarderAndroid/app/src/main/java/com/cisco/hicn/forwarder/preferences/PreferencesFragment.java
+++ b/HicnForwarderAndroid/app/src/main/java/com/cisco/hicn/forwarder/preferences/PreferencesFragment.java
@@ -40,9 +40,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
     @Override
     public void onCreatePreferences(Bundle bundle, String s) {
 
-        HProxy hProxy = HProxy.getInstance();
-
-        if (hProxy.isHProxyEnabled()) {
+        if (HProxy.isHProxyEnabled()) {
             setPreferencesFromResource(R.xml.root_proxy, s);
         } else {
             setPreferencesFromResource(R.xml.root_no_proxy, s);

--- a/HicnForwarderAndroid/app/src/main/java/com/cisco/hicn/forwarder/service/ProxyThread.java
+++ b/HicnForwarderAndroid/app/src/main/java/com/cisco/hicn/forwarder/service/ProxyThread.java
@@ -50,13 +50,13 @@ public class ProxyThread implements Runnable {
     private String mHicnProducerName;
     private BackendProxyService mBackendProxyService;
 
-
-    private HProxy mProxyInstance;
+    private HProxy mProxyInstance = null;
     private ParcelFileDescriptor mInterface;
     private Properties mParameters;
 
     public ProxyThread(final VpnService service, final int connectionId,
                        final String serverName, final int serverPort, final String secret) {
+        mProxyInstance = new HProxy();
         mService = service;
         mConnectionId = connectionId;
         mServerName = serverName;
@@ -107,7 +107,7 @@ public class ProxyThread implements Runnable {
 
         // If we arrived here it means no error occurred during configuration.
         // Now create the instance of the proxy and configure it.
-        mProxyInstance = HProxy.getInstance();
+
 
         // start Service and block
         // Get instance of forwarder
@@ -125,7 +125,13 @@ public class ProxyThread implements Runnable {
 
         Log.i(getTag(), "HProxy stopped.");
 
+        mProxyInstance.destroy();
+
         return true;
+    }
+
+    public void stop() {
+        mProxyInstance.stop();
     }
 
     public int configureTun(Properties parameters) {
@@ -158,12 +164,11 @@ public class ProxyThread implements Runnable {
         }
 
         PackageManager packageManager = mService.getPackageManager();
-        HProxy hproxy = HProxy.getInstance();
         try {
-            packageManager.getPackageInfo(hproxy.getProxifiedPackageName(), 0);
-            builder.addAllowedApplication(hproxy.getProxifiedPackageName());
+            packageManager.getPackageInfo(HProxy.getProxifiedPackageName(), 0);
+            builder.addAllowedApplication(HProxy.getProxifiedPackageName());
         } catch (PackageManager.NameNotFoundException e) {
-            Log.e(getTag(), hproxy.getProxifiedAppName() + " is not installed.");
+            Log.e(getTag(), HProxy.getProxifiedAppName() + " is not installed.");
         }
 
         // Close the old interface since the parameters have been changed.

--- a/HicnForwarderAndroid/app/src/main/java/com/cisco/hicn/forwarder/supportlibrary/HProxy.java
+++ b/HicnForwarderAndroid/app/src/main/java/com/cisco/hicn/forwarder/supportlibrary/HProxy.java
@@ -21,31 +21,20 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class HProxy {
-    private static HProxy sInstance = null;
-    private AtomicInteger mNextConnectorId = new AtomicInteger(1);
-
-    private int mVpnConnector = -1;
-    private int mUdpTunnelConnector = -1;
-    private int mIcnConnector = -1;
+//    private static HProxy sInstance = null;
     private ProxyThread mProxyThread;
+
+    // This will sotre the actual pointer to the proxy
+    private long mProxyPtr = 0;
 
     static {
         System.loadLibrary("hproxy-wrapper");
     }
 
-    public static HProxy getInstance() {
-        if (sInstance == null) {
-            sInstance = new HProxy();
-        }
-        return sInstance;
-    }
+    public HProxy() { initConfig(); }
 
     public void setProxyInstance(ProxyThread proxyThread) {
         mProxyThread = proxyThread;
-    }
-
-    private HProxy() {
-        initConfig();
     }
 
     public native void initConfig();
@@ -73,8 +62,10 @@ public class HProxy {
 
     public native void stop();
 
-    public native boolean isHProxyEnabled();
+    public native void destroy();
 
-    public native String getProxifiedAppName();
-    public native String getProxifiedPackageName();
+    public static native boolean isHProxyEnabled();
+
+    public static native String getProxifiedAppName();
+    public static native String getProxifiedPackageName();
 }

--- a/HicnForwarderAndroid/app/src/main/jni/hproxy-wrapper.cpp
+++ b/HicnForwarderAndroid/app/src/main/jni/hproxy-wrapper.cpp
@@ -69,7 +69,7 @@ Java_com_cisco_hicn_forwarder_supportlibrary_HProxy_destroy(JNIEnv *env, jobject
 #ifdef ENABLE_HPROXY
     HicnProxy *proxy = (HicnProxy *) env->GetLongField(instance, getPtrFieldId(env, instance,
                                                                                HPROXY_ATTRIBUTE));
-    auto jni_context = proxy->getJniContext();
+    JniContext *jni_context = (JniContext *)proxy->getJniContext();
     delete jni_context;
     delete proxy;
 #endif
@@ -176,7 +176,7 @@ Java_com_cisco_hicn_forwarder_supportlibrary_HProxy_stop(JNIEnv *env, jobject in
     if (proxy) {
         proxy->stop();
     }
-#endifgit
+#endif
 }
 
 extern "C" JNIEXPORT jstring JNICALL

--- a/HicnForwarderAndroid/app/src/main/jni/hproxy-wrapper.cpp
+++ b/HicnForwarderAndroid/app/src/main/jni/hproxy-wrapper.cpp
@@ -66,6 +66,9 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_cisco_hicn_forwarder_supportlibrary_HProxy_destroy(JNIEnv *env, jobject instance) {
 #ifdef ENABLE_HPROXY
     HicnProxy* proxy = (HicnProxy*) env->GetLongField(instance, getPtrFieldId(env, instance, "mProxyPtr"));
+    auto jni_context = proxy->getJniContext();
+    delete jni_context;
+    delete proxy;
 #endif
 }
 

--- a/HicnForwarderAndroid/app/src/main/jni/hproxy-wrapper.cpp
+++ b/HicnForwarderAndroid/app/src/main/jni/hproxy-wrapper.cpp
@@ -12,13 +12,15 @@ using HicnProxy = hproxy::HicnProxy;
 
 struct JniContext {
     JniContext() : env(nullptr), instance(nullptr) {}
+
     JNIEnv *env;
     jobject *instance;
 };
+
 #endif
 
 // Get pointer field straight from `JavaClass`
-jfieldID getPtrFieldId(JNIEnv * env, jobject obj, std::string attribute_name) {
+jfieldID getPtrFieldId(JNIEnv *env, jobject obj, std::string attribute_name) {
     static jfieldID ptrFieldId = 0;
 
     if (!ptrFieldId) {
@@ -57,7 +59,7 @@ Java_com_cisco_hicn_forwarder_supportlibrary_HProxy_start(JNIEnv *env, jobject i
 
     auto proxy = HicnProxy::createAsClient(config_connector, config_automation).release();
     proxy->setJniContext(context);
-    env->SetLongField(instance, getPtrFieldId(env, instance, "mProxyPtr"), (jlong) proxy);
+    env->SetLongField(instance, getPtrFieldId(env, instance, HPROXY_ATTRIBUTE), (jlong) proxy);
     proxy->run();
 #endif
 }
@@ -65,7 +67,8 @@ Java_com_cisco_hicn_forwarder_supportlibrary_HProxy_start(JNIEnv *env, jobject i
 extern "C" JNIEXPORT void JNICALL
 Java_com_cisco_hicn_forwarder_supportlibrary_HProxy_destroy(JNIEnv *env, jobject instance) {
 #ifdef ENABLE_HPROXY
-    HicnProxy* proxy = (HicnProxy*) env->GetLongField(instance, getPtrFieldId(env, instance, "mProxyPtr"));
+    HicnProxy *proxy = (HicnProxy *) env->GetLongField(instance, getPtrFieldId(env, instance,
+                                                                               HPROXY_ATTRIBUTE));
     auto jni_context = proxy->getJniContext();
     delete jni_context;
     delete proxy;
@@ -75,7 +78,8 @@ Java_com_cisco_hicn_forwarder_supportlibrary_HProxy_destroy(JNIEnv *env, jobject
 extern "C" JNIEXPORT jboolean JNICALL
 Java_com_cisco_hicn_forwarder_supportlibrary_HProxy_isRunning(JNIEnv *env, jobject instance) {
 #ifdef ENABLE_HPROXY
-    HicnProxy* proxy = (HicnProxy*) env->GetLongField(instance, getPtrFieldId(env, instance, "mProxyPtr"));
+    HicnProxy *proxy = (HicnProxy *) env->GetLongField(instance, getPtrFieldId(env, instance,
+                                                                               HPROXY_ATTRIBUTE));
     if (proxy) {
         return jboolean(proxy->isRunning());
     }
@@ -123,7 +127,7 @@ extern "C" int createTunDevice(const char *vpn_address, uint16_t prefix_length,
                                const char *route_address,
                                uint16_t route_prefix_length, const char *dns, void *context) {
 #ifdef ENABLE_HPROXY
-    JniContext *jni_context= (JniContext*)(context);
+    JniContext *jni_context = (JniContext *) (context);
 
     if (!jni_context->env || !jni_context->instance) {
         __android_log_print(ANDROID_LOG_ERROR, "HProxyWrap",
@@ -131,7 +135,8 @@ extern "C" int createTunDevice(const char *vpn_address, uint16_t prefix_length,
         return -1;
     }
 
-    return createTunDeviceWrap(jni_context->env, *jni_context->instance, vpn_address, prefix_length, route_address,
+    return createTunDeviceWrap(jni_context->env, *jni_context->instance, vpn_address, prefix_length,
+                               route_address,
                                route_prefix_length, dns);
 #else
     return 0;
@@ -140,7 +145,7 @@ extern "C" int createTunDevice(const char *vpn_address, uint16_t prefix_length,
 
 extern "C" int closeTunDevice(void *context) {
 #ifdef ENABLE_HPROXY
-    JniContext *jni_context= (JniContext*)(context);
+    JniContext *jni_context = (JniContext *) (context);
     if (!jni_context->env || !jni_context->instance) {
         __android_log_print(ANDROID_LOG_ERROR, "HProxyWrap",
                             "Call createTunDevice, but _env and _instance variables are not initialized.");
@@ -166,11 +171,12 @@ Java_com_cisco_hicn_forwarder_supportlibrary_HProxy_isHProxyEnabled(JNIEnv *env,
 extern "C" JNIEXPORT void JNICALL
 Java_com_cisco_hicn_forwarder_supportlibrary_HProxy_stop(JNIEnv *env, jobject instance) {
 #ifdef ENABLE_HPROXY
-    HicnProxy* proxy = (HicnProxy*) env->GetLongField(instance, getPtrFieldId(env, instance, "mProxyPtr"));
+    HicnProxy *proxy = (HicnProxy *) env->GetLongField(instance, getPtrFieldId(env, instance,
+                                                                               HPROXY_ATTRIBUTE));
     if (proxy) {
         proxy->stop();
     }
-#endif
+#endifgit
 }
 
 extern "C" JNIEXPORT jstring JNICALL


### PR DESCRIPTION
Signed-off-by: Mauro Sardara <msardara@cisco.com>