### PR TITLE
All calls to bindSocket can fail, thereby preventing face creation

### DIFF
--- a/HicnForwarderAndroid/app/src/main/java/com/cisco/hicn/forwarder/supportlibrary/NetworkServiceHelper.java
+++ b/HicnForwarderAndroid/app/src/main/java/com/cisco/hicn/forwarder/supportlibrary/NetworkServiceHelper.java
@@ -59,7 +59,7 @@ public class NetworkServiceHelper {
 
     private void requestMobileNetwork() {
         final int[] transportTypes = new int[]{NetworkCapabilities.TRANSPORT_CELLULAR};
-        final int[] capabilities = new int[]{NetworkCapabilities.NET_CAPABILITY_INTERNET};
+        final int[] capabilities = new int[]{NetworkCapabilities.NET_CAPABILITY_INTERNET | NetworkCapabilities.NET_CAPABILITY_NOT_VPN};
 
         if (mMobileNetworkCallback != null) {
             Log.d(TAG, "Already mobile network requested");
@@ -78,7 +78,8 @@ public class NetworkServiceHelper {
 
     private void requestWifiNetwork() {
         final int[] transportTypes = new int[]{NetworkCapabilities.TRANSPORT_WIFI};
-        final int[] capabilities = new int[]{NetworkCapabilities.NET_CAPABILITY_INTERNET};
+        final int[] capabilities = new int[]{NetworkCapabilities.NET_CAPABILITY_INTERNET | NetworkCapabilities.NET_CAPABILITY_NOT_VPN};
+
 
         if (mWifiNetworkCallback != null) {
             Log.d(TAG, "Already Wi-Fi network requested");


### PR DESCRIPTION
NetworkServiceHelper registers tunnels instead of regular wireless interfaces and causes bindSocket to fail by times

If a TUN interface is present on the device and routed over WiFi for instance, the NetworkServiceHelper will register it in place of the true WiFi interface (say wlan0) causing further calls to bindSocket on wlan0 to fail, and thus the interface not being created in hICN.

Steps to reproduce: stop and start again hICN rather quickly