### PR TITLE
Fix wrong NetworkCapabilities definition to request network

### DIFF
--- a/HicnForwarderAndroid/app/src/main/java/com/cisco/hicn/forwarder/supportlibrary/NetworkServiceHelper.java
+++ b/HicnForwarderAndroid/app/src/main/java/com/cisco/hicn/forwarder/supportlibrary/NetworkServiceHelper.java
@@ -59,7 +59,7 @@ public class NetworkServiceHelper {
 
     private void requestMobileNetwork() {
         final int[] transportTypes = new int[]{NetworkCapabilities.TRANSPORT_CELLULAR};
-        final int[] capabilities = new int[]{NetworkCapabilities.NET_CAPABILITY_INTERNET | NetworkCapabilities.NET_CAPABILITY_NOT_VPN};
+        final int[] capabilities = new int[]{NetworkCapabilities.NET_CAPABILITY_INTERNET, NetworkCapabilities.NET_CAPABILITY_NOT_VPN};
 
         if (mMobileNetworkCallback != null) {
             Log.d(TAG, "Already mobile network requested");
@@ -78,7 +78,7 @@ public class NetworkServiceHelper {
 
     private void requestWifiNetwork() {
         final int[] transportTypes = new int[]{NetworkCapabilities.TRANSPORT_WIFI};
-        final int[] capabilities = new int[]{NetworkCapabilities.NET_CAPABILITY_INTERNET | NetworkCapabilities.NET_CAPABILITY_NOT_VPN};
+        final int[] capabilities = new int[]{NetworkCapabilities.NET_CAPABILITY_INTERNET, NetworkCapabilities.NET_CAPABILITY_NOT_VPN};
 
 
         if (mWifiNetworkCallback != null) {


### PR DESCRIPTION
NetworkCapabilities cannot be OR-ed as a single value. Multiple capabilities must be defined as a array form.